### PR TITLE
feat: initial implementation (no update-motd mimic implementation)

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/JonasPammer/cookiecutter-ansible-role.git",
-  "commit": "36f7a5ba811bfc68faf1aa16abe956bc9e695775",
+  "commit": "0a7f5665d093bd499a0c56e6b8d246f2bae80425",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.cruft.json
+++ b/.cruft.json
@@ -13,7 +13,7 @@
       "allow_duplicates": "no",
       "ansible_user_needs_to_become": "True",
       "role_name": "motd",
-      "project_short_purpose": "configuring login banners on linux machines",
+      "project_short_purpose": "configuring either static (traditional) or dynamic (using `update-motd` framework) login banners on linux machines.",
       "_template": "https://github.com/JonasPammer/cookiecutter-ansible-role.git"
     }
   },

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/JonasPammer/cookiecutter-ansible-role.git",
-  "commit": "0a7f5665d093bd499a0c56e6b8d246f2bae80425",
+  "commit": "dc270eefaaf9901755c87969047f42f97cd04470",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/README.adoc
+++ b/README.adoc
@@ -32,8 +32,10 @@ JonasPammer.github.io/ansible-role-motd].__
 endif::[]
 
 
-An Ansible role for configuring either static (traditional) or dynamic
-(using `update-motd` framework) login banners on linux machines.
+An Ansible role for configuring static and dynamic login banners on linux machines.
+
+For configuring OpenSSH's Banner, see
+https://github.com/JonasPammer/ansible-role-openssh/[ansible-role-openssh].
 
 
 toc::[]
@@ -72,9 +74,9 @@ must be installed on the Ansible controller.
 
 [source,yaml]
 ----
-motd_type: [OS-specific for v1, see TODO /defaults directory]
+motd_type: [OS-specific for v1, see TODO in setup-update-motd.yml]
 ----
-The MOTD can be implemented in 2 manners:
+A MOTD can be implemented in 2 manners:
 
 "`static`"::
 Generate a single static `/etc/motd` text file and
@@ -82,10 +84,10 @@ dismantle update-motd's scripts so only this file is being shown by `pam_motd`
 (traditional motd).
 
 "`update-motd`"::
-Activate's the `update-motd` functionality
+Activate the `update-motd` functionality
 https://www.systutorials.com/docs/linux/man/5-update-motd/[(nicely described in Ubuntu's MAN Page)],
 by which the motd is dynamically assembled from a collection of scripts
-(at login or periodically through cron).
+at login or periodically through the use of a `cron` job.
 +
 This role will delete the traditional `/etc/motd` file,
 leaving only the output of the scripts to be included in the assembled motd.
@@ -98,6 +100,23 @@ Additional Relevant Reading Material on the `update-motd` topic:
 * https://ownyourbits.com/2017/04/05/customize-your-motd-login-message-in-debian-and-ubuntu/[
 Blog Post describing update-motd's history and implementation details]
 * https://wiki.ubuntu.com/UpdateMotd[UbuntuWiki's Proposal]
+
+=== Static MOTD Configuration Variables
+
+[source,yaml]
+----
+motd_static_motd_template: "issue.net"
+----
+Path to Ansible template ending in `.jinja2`.
+
+[NOTE]
+====
+This role comes bundled with a pre-defined legal banner.
+To use your own templates, ensure your template do not wear the exact names
+as the one in link:templates[this roles' `templates` directory].
+====
+
+=== Dynamic MOTD Configuration Variables
 
 [source,yaml]
 ----
@@ -130,24 +149,26 @@ Must *not* end with `/`.
 
 [source,yaml]
 ----
-motd_dynamic_scripts_backup_undefined: true
-motd_dynamic_scripts_backup_undefined_path: "{{ motd_dynamic_scripts_directory }}-backup_{{ ansible_date_time.iso8601_basic_short }}"
+motd_dynamic_scripts_backup: false
+motd_dynamic_scripts_backup_path: "{{ motd_dynamic_scripts_directory }}-backup"
 ----
 This role ensures that `motd_dynamic_scripts_directory`
 *only* contains the files stated in `motd_dynamic_scripts_templates`.
 
-If this variable is set to true,
-the undefined files will be moved to a new directory with the dynamic name of
-`{{ motd_dynamic_scripts_backup_undefined_path }}`.
+These variables define whether and where to backup files
+found in the mentioned directory that are not included in the list
+of this role's defined script template names.
 
 [source,yaml]
 ----
-motd_static_motd_backup: true
-motd_static_motd_backup_path: "/etc/motd-backup_{{ ansible_date_time.iso8601_basic_short }}"
+motd_static_motd_backup: false
+motd_static_motd_backup_path: "/etc/motd-backup"
 ----
-If a file with the name `/etc/motd` is found,
-these variables define whether and where a copy of this file should be stored
-before deleting the mentioned file.
+This role ensure's that only the dynamic scripts
+have influence on the resulting motd.
+
+If `/etc/motd` is found to be a normal text file,
+these variables define whether and where to backup this file.
 
 
 [[public_vars]]

--- a/README.adoc
+++ b/README.adoc
@@ -248,22 +248,22 @@ Resulting dynamic MOTD (example):
    \_/__________________________________________________________________________________/
 
        _,met$$$$$gg.          user@srvweb
-    ,g$$$$$$$$$$$$$$$P.       ------------ 
-  ,g$$P"     """Y$$.".        OS: Debian GNU/Linux 9.13 (stretch) x86_64 
- ,$$P'              `$$$.     Model: Standard PC (i440FX + PIIX, 1996) pc-i440f 
-',$$P       ,ggs.     `$$b:   Kernel: 4.9.0-16-amd64 
-`d$$'     ,$P"'   .    $$$    Uptime: 74 days, 19 hours, 42 minutes 
- $$P      d$'     ,    $$P    Packages: 920 
- $$:      $$.   -    ,d$$'    Shell: bash 4.4.12 
- $$;      Y$b._   _,d$P'      Terminal: run-parts 
- Y$$.    `.`"Y$$$$P"'         CPU: Common KVM (2) @ 1.7GHz 
- `$$b      "-.__              GPU: Vendor 1234 Device 1111 
-  `Y$$                        Memory: 1858MB / 3955MB 
-   `Y$$.                       
-     `$$b.                    ████████████████████████ 
-       `Y$$b.                  
-          `"Y$b._ 
-              `""" 
+    ,g$$$$$$$$$$$$$$$P.       ------------
+  ,g$$P"     """Y$$.".        OS: Debian GNU/Linux 9.13 (stretch) x86_64
+ ,$$P'              `$$$.     Model: Standard PC (i440FX + PIIX, 1996) pc-i440f
+',$$P       ,ggs.     `$$b:   Kernel: 4.9.0-16-amd64
+`d$$'     ,$P"'   .    $$$    Uptime: 74 days, 19 hours, 42 minutes
+ $$P      d$'     ,    $$P    Packages: 920
+ $$:      $$.   -    ,d$$'    Shell: bash 4.4.12
+ $$;      Y$b._   _,d$P'      Terminal: run-parts
+ Y$$.    `.`"Y$$$$P"'         CPU: Common KVM (2) @ 1.7GHz
+ `$$b      "-.__              GPU: Vendor 1234 Device 1111
+  `Y$$                        Memory: 1858MB / 3955MB
+   `Y$$.
+     `$$b.                    ████████████████████████
+       `Y$$b.
+          `"Y$b._
+              `"""
 ----
 ====
 
@@ -274,7 +274,7 @@ Resulting dynamic MOTD (example):
 roles:
   - "jonaspammer.motd"
 
-vars: 
+vars:
   motd_type: static
   motd_legal_location_name: My Company # OPTIONAL variable used by built-in template
 ----
@@ -307,7 +307,7 @@ LOG OFF IMMEDIATELY if you do not agree to the conditions stated in this warning
 roles:
   - "jonaspammer.motd"
 
-vars: 
+vars:
   motd_type: static
   motd_static_motd_template: my-template
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,8 @@ JonasPammer.github.io/ansible-role-motd].__
 endif::[]
 
 
-An Ansible role for configuring login banners on linux machines.
+An Ansible role for configuring either static (traditional) or dynamic
+(using `update-motd` framework) login banners on linux machines.
 
 
 toc::[]
@@ -72,24 +73,82 @@ must be installed on the Ansible controller.
 
 [source,yaml]
 ----
-variable: default value
+motd_type: [OS-specific for v1, see TODO /defaults directory]
 ----
-Description
+The MOTD can be implemented in 2 manners:
 
+"`static`"::
+Generate a single static `/etc/motd` text file and
+dismantle update-motd's scripts so only this file is being shown by `pam_motd`
+(traditional motd).
+
+"`update-motd`"::
+Activate's the `update-motd` functionality
+https://www.systutorials.com/docs/linux/man/5-update-motd/[(nicely described in Ubuntu's MAN Page)],
+by which the motd is dynamically assembled from a collection of scripts
+(at login or periodically through cron).
++
+This role will delete the traditional `/etc/motd` file,
+leaving only the output of the scripts to be included in the assembled motd.
++
+This role will install its own `update-motd` Implementation on systems
+without this functionality built into their version of `pam_motd`.
++
+Additional Relevant Reading Material on the `update-motd` topic:
++
+* https://ownyourbits.com/2017/04/05/customize-your-motd-login-message-in-debian-and-ubuntu/[
+Blog Post describing update-motd's history and implementation details]
+* https://wiki.ubuntu.com/UpdateMotd[UbuntuWiki's Proposal]
 
 [source,yaml]
 ----
-variable: [OS-specific by default, see /vars directory]
+motd_dynamic_scripts_system_packages: [OS-specific, see /defaults directory]
 ----
-Description
-
+Packages to be installed by this role using
+https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html[Ansible's package module].
 
 [source,yaml]
 ----
-variable: [OS-specific by default, see /vars directory]
+motd_dynamic_scripts_templates:
+  - "00-legal" # in case SSH-Banner didn't show
+  - "10-sysinfo"
 ----
-(Debian/Ubuntu only)
-Description
+Path to Ansible templates ending in `.jinja2` that are to be generated into `motd_dynamic_scripts_directory`.
+
+[NOTE]
+====
+This role comes bundled with some already defined templates.
+To use your own templates, ensure your templates do not wear the exact names
+as the ones in link:templates[this roles' `templates` directory].
+====
+
+[source,yaml]
+----
+motd_dynamic_scripts_directory: [OS-specific by default, see /vars directory]
+----
+Path to store the templated `motd_dynamic_scripts_templates`.
+Must *not* end with `/`.
+
+[source,yaml]
+----
+motd_dynamic_scripts_backup_undefined: true
+motd_dynamic_scripts_backup_undefined_path: "{{ motd_dynamic_scripts_directory }}-backup_{{ ansible_date_time.iso8601_basic_short }}"
+----
+This role ensures that `motd_dynamic_scripts_directory`
+*only* contains the files stated in `motd_dynamic_scripts_templates`.
+
+If this variable is set to true,
+the undefined files will be moved to a new directory with the dynamic name of
+`{{ motd_dynamic_scripts_backup_undefined_path }}`.
+
+[source,yaml]
+----
+motd_static_motd_backup: true
+motd_static_motd_backup_path: "/etc/motd-backup_{{ ansible_date_time.iso8601_basic_short }}"
+----
+If a file with the name `/etc/motd` is found,
+these variables define whether and where a copy of this file should be stored
+before deleting the mentioned file.
 
 
 [[dependencies]]

--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,6 @@ endif::[]
 
 // Very Relevant Status Badges
 https://github.com/JonasPammer/ansible-role-motd/actions/workflows/ci.yml[image:https://github.com/JonasPammer/ansible-role-motd/actions/workflows/ci.yml/badge.svg[Testing CI]]
-https://app.fossa.com/projects/git%2Bgithub.com%2FJonasPammer%2Fansible-role-motd?ref=badge_shield[image:https://app.fossa.com/api/projects/git%2Bgithub.com%2FJonasPammer%2Fansible-role-motd.svg?type=small[FOSSA Licenses Status]]
 
 // Badges about Conventions in this Project
 https://conventionalcommits.org[image:https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg[Conventional Commits]]
@@ -151,6 +150,14 @@ these variables define whether and where a copy of this file should be stored
 before deleting the mentioned file.
 
 
+[[public_vars]]
+== 📜 Facts/Variables defined by this role
+
+Each variable listed in this section
+is dynamically defined when executing this role (and can only be overwritten using `ansible.builtin.set_facts`) _and_
+is meant to be used not just internally.
+
+
 [[dependencies]]
 == 👫 Dependencies
 // A list of other roles should go here,
@@ -226,5 +233,3 @@ Please report any accidental breaking changes of a minor version update.
 ----
 include::LICENSE[]
 ----
-
-https://app.fossa.com/projects/git%2Bgithub.com%2FJonasPammer%2Fansible-role-motd?ref=badge_large[image:https://app.fossa.com/api/projects/git%2Bgithub.com%2FJonasPammer%2Fansible-role-motd.svg?type=large[FOSSA Licensing Information]]

--- a/README.adoc
+++ b/README.adoc
@@ -213,15 +213,110 @@ image:https://raw.githubusercontent.com/JonasPammer/ansible-roles/master/graphs/
 requirements.yml dependency graph of jonaspammer.motd]
 ====
 
-.Minimum Viable Play
+.Configuring a Dynamic MOTD using the role's built-in templates
 ====
 [source,yaml]
 ----
 roles:
-    - "jonaspammer.motd"
+  - "jonaspammer.motd"
 
 vars:
-    some_var: "some_value"
+  motd_legal_location_name: MY COMPANY INTRA # OPTIONAL variable used by built-in template
+----
+
+Resulting dynamic MOTD (example):
+
+----
+ _____________________________________________________________________________________
+/\                                                                                    \
+\_| You are connecting to the computer system 'srvweb' at MY COMPANY INTRA.           |
+  |                                                                                   |
+  | Any or all uses of this system and all files on this system may be                |
+  | intercepted, monitored, recorded, copied, audited, inspected,                     |
+  | and disclosed to authorized corporation and law enforcement personnel,            |
+  | as well as authorized individuals of other organizations.                         |
+  | By using this system, the user consents to such interception,                     |
+  | monitoring, recording, copying, auditing, inspection,                             |
+  | and disclosure at the discretion of authorized personnel.                         |
+  |                                                                                   |
+  | Unauthorized or improper use of this system may result in                         |
+  | administrative disciplinary action, civil charges/criminal penalties,             |
+  | and/or other sanctions as according to the european codes and/or countries codes. |
+  |                                                                                   |
+  | LOG OFF IMMEDIATELY if you do not agree to the conditions stated in this warning. |
+  |   ________________________________________________________________________________|_
+   \_/__________________________________________________________________________________/
+
+       _,met$$$$$gg.          user@srvweb
+    ,g$$$$$$$$$$$$$$$P.       ------------ 
+  ,g$$P"     """Y$$.".        OS: Debian GNU/Linux 9.13 (stretch) x86_64 
+ ,$$P'              `$$$.     Model: Standard PC (i440FX + PIIX, 1996) pc-i440f 
+',$$P       ,ggs.     `$$b:   Kernel: 4.9.0-16-amd64 
+`d$$'     ,$P"'   .    $$$    Uptime: 74 days, 19 hours, 42 minutes 
+ $$P      d$'     ,    $$P    Packages: 920 
+ $$:      $$.   -    ,d$$'    Shell: bash 4.4.12 
+ $$;      Y$b._   _,d$P'      Terminal: run-parts 
+ Y$$.    `.`"Y$$$$P"'         CPU: Common KVM (2) @ 1.7GHz 
+ `$$b      "-.__              GPU: Vendor 1234 Device 1111 
+  `Y$$                        Memory: 1858MB / 3955MB 
+   `Y$$.                       
+     `$$b.                    ████████████████████████ 
+       `Y$$b.                  
+          `"Y$b._ 
+              `""" 
+----
+====
+
+.Configuring a Static MOTD using the role's built-in template
+====
+[source,yaml]
+----
+roles:
+  - "jonaspammer.motd"
+
+vars: 
+  motd_type: static
+  motd_legal_location_name: My Company # OPTIONAL variable used by built-in template
+----
+
+Resulting static MOTD (example):
+
+----
+You are connecting to the computer system 'srvweb' at My Company.
+
+Any or all uses of this system and all files on this system may be
+intercepted, monitored, recorded, copied, audited, inspected,
+and disclosed to authorized corporation and law enforcement personnel,
+as well as authorized individuals of other organizations.
+By using this system, the user consents to such interception,
+monitoring, recording, copying, auditing, inspection,
+and disclosure at the discretion of authorized personnel.
+
+Unauthorized or improper use of this system may result in
+administrative disciplinary action, civil charges/criminal penalties,
+and/or other sanctions as according to the european codes and/or countries codes.
+
+LOG OFF IMMEDIATELY if you do not agree to the conditions stated in this warning.
+----
+====
+
+.Configuring a Static MOTD with own templates
+====
+[source,yaml]
+----
+roles:
+  - "jonaspammer.motd"
+
+vars: 
+  motd_type: static
+  motd_static_motd_template: my-template
+----
+
+.templates/my-template.jinja2
+[source,jinja2]
+----
+{{ ansible_managed | comment }}
+Welcome to {{ ansible_host }}
 ----
 ====
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,8 @@ _motd_type:
   default: static # TODO only for now see setup-update-motd.yml
 
 motd_static_motd_template: "issue.net"
-motd_static_motd_backup: true
-motd_static_motd_backup_path: "/etc/motd-backup_{{ ansible_date_time.iso8601_basic_short }}"
+motd_static_motd_backup: false
+motd_static_motd_backup_path: "/etc/motd-backup"
 
 _motd_dynamic_scripts_system_packages:
   Debian:
@@ -16,15 +16,12 @@ _motd_dynamic_scripts_system_packages:
     - neofetch
     - screenfetch
 
-motd_dynamic_delete_static: true
 motd_dynamic_scripts_templates:
   - "00-legal" # in case SSH-Banner didn't show
   - "10-sysinfo"
-motd_dynamic_scripts_backup: true
-motd_dynamic_scripts_backup_path: "{{ motd_dynamic_scripts_directory }}-backup_{{ ansible_date_time.iso8601_basic_short }}"
+motd_dynamic_scripts_backup: false
+motd_dynamic_scripts_backup_path: "{{ motd_dynamic_scripts_directory }}-backup"
 
-_motd_dynamic_scripts_directory:
-  default: "/etc/update-motd.d"
 
 motd_type: "{{
   _motd_type[ansible_distribution ~ '_' ~ ansible_distribution_major_version]|default(

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,48 @@
 ---
 # defaults file of ansible-role jonaspammer.motd
 # See README.adoc for documentation. If you change a default here, also update it in the README.
+
+_motd_type:
+  Ubuntu: update-motd
+  default: static # TODO only for now see setup-update-motd.yml
+
+motd_static_motd_template: "issue.net"
+motd_static_motd_backup: true
+motd_static_motd_backup_path: "/etc/motd-backup_{{ ansible_date_time.iso8601_basic_short }}"
+
+_motd_dynamic_scripts_system_packages:
+  Debian:
+    - boxes
+    - neofetch
+    - screenfetch
+
+motd_dynamic_delete_static: true
+motd_dynamic_scripts_templates:
+  - "00-legal" # in case SSH-Banner didn't show
+  - "10-sysinfo"
+motd_dynamic_scripts_backup: true
+motd_dynamic_scripts_backup_path: "{{ motd_dynamic_scripts_directory }}-backup_{{ ansible_date_time.iso8601_basic_short }}"
+
+_motd_dynamic_scripts_directory:
+  Debian: "/etc/update-motd.d"
+
+motd_type: "{{
+  _motd_type[ansible_distribution ~ '_' ~ ansible_distribution_major_version]|default(
+  _motd_type[ansible_os_family ~ '_' ~ ansible_distribution_major_version])|default(
+  _motd_type[ansible_distribution])|default(
+  _motd_type[ansible_os_family])|default(
+  _motd_type['default']) }}"
+
+motd_dynamic_scripts_system_packages: "{{
+  _motd_dynamic_scripts_system_packages[ansible_distribution ~ '_' ~ ansible_distribution_major_version]|default(
+  _motd_dynamic_scripts_system_packages[ansible_os_family ~ '_' ~ ansible_distribution_major_version])|default(
+  _motd_dynamic_scripts_system_packages[ansible_distribution])|default(
+  _motd_dynamic_scripts_system_packages[ansible_os_family])|default(
+  _motd_dynamic_scripts_system_packages['default']) }}"
+
+motd_dynamic_scripts_directory: "{{
+  _motd_dynamic_scripts_directory[ansible_distribution ~ '_' ~ ansible_distribution_major_version]|default(
+  _motd_dynamic_scripts_directory[ansible_os_family ~ '_' ~ ansible_distribution_major_version])|default(
+  _motd_dynamic_scripts_directory[ansible_distribution])|default(
+  _motd_dynamic_scripts_directory[ansible_os_family])|default(
+  _motd_dynamic_scripts_directory['default']) }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ motd_dynamic_scripts_backup: true
 motd_dynamic_scripts_backup_path: "{{ motd_dynamic_scripts_directory }}-backup_{{ ansible_date_time.iso8601_basic_short }}"
 
 _motd_dynamic_scripts_directory:
-  Debian: "/etc/update-motd.d"
+  default: "/etc/update-motd.d"
 
 motd_type: "{{
   _motd_type[ansible_distribution ~ '_' ~ ansible_distribution_major_version]|default(

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,6 @@ motd_dynamic_scripts_templates:
 motd_dynamic_scripts_backup: false
 motd_dynamic_scripts_backup_path: "{{ motd_dynamic_scripts_directory }}-backup"
 
-
 motd_type: "{{
   _motd_type[ansible_distribution ~ '_' ~ ansible_distribution_major_version]|default(
   _motd_type[ansible_os_family ~ '_' ~ ansible_distribution_major_version])|default(

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,9 @@
 ---
 galaxy_info:
   role_name: "motd"
-  description: "An ansible role for configuring login banners on linux machines."
+  description:
+    "An ansible role for configuring either static (traditional) or dynamic
+    (using `update-motd` framework) login banners on linux machines."
 
   author: "jonaspammer"
   license: MIT

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -6,5 +6,5 @@
 
   roles:
     - role: jonaspammer.bootstrap
-    #    - role: jonaspammer.core_dependencies
+    - role: jonaspammer.core_dependencies
     - role: jonaspammer.shellcheck

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -7,3 +7,4 @@
   roles:
     - role: jonaspammer.bootstrap
     - role: jonaspammer.core_dependencies
+    - role: jonaspammer.shellcheck

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -6,5 +6,5 @@
 
   roles:
     - role: jonaspammer.bootstrap
-    - role: jonaspammer.core_dependencies
+    #    - role: jonaspammer.core_dependencies
     - role: jonaspammer.shellcheck

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,6 +2,7 @@
 roles:
   - name: jonaspammer.bootstrap
   - name: jonaspammer.core_dependencies
+  - name: jonaspammer.shellcheck
 collections:
   - name: community.docker # only needed for molecule execution
   - name: community.general

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 roles:
   - name: jonaspammer.bootstrap
-  - name: jonaspammer.core_dependencies
+#  - name: jonaspammer.core_dependencies
   - name: jonaspammer.shellcheck
 collections:
   - name: community.docker # only needed for molecule execution

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 roles:
   - name: jonaspammer.bootstrap
-#  - name: jonaspammer.core_dependencies
+  - name: jonaspammer.core_dependencies
   - name: jonaspammer.shellcheck
 collections:
   - name: community.docker # only needed for molecule execution

--- a/tasks/add-dynamic-script.yml
+++ b/tasks/add-dynamic-script.yml
@@ -1,0 +1,36 @@
+---
+# tasks file of ansible-role jonaspammer.motd
+
+# TODO use ansible-integrated way of doing this.
+#      https://docs.ansible.com/ansible/devel/reference_appendices/faq.html#the-validate-option-is-not-enough-for-my-needs-what-do-i-do
+- name: Generate dynamic MOTD script '{{ looped_script_template }}' and ensure correct owner/group/mode.
+  ansible.builtin.template:
+    src: "{{ looped_script_template }}.jinja2"
+    dest: "{{ motd__register_tempfile_dynamic_motds.path }}/{{ looped_script_template }}"
+    owner: root
+    group: root
+    mode: u=rwx,g=rx,o=rx
+  changed_when: false # reason: tempfile
+
+- name: ShellCheck templated motd script  '{{ looped_script_template }}' (--severity=error).
+  ansible.builtin.shell: "shellcheck {{ motd__register_tempfile_dynamic_motds.path }}/{{ looped_script_template }} --severity=error"
+  changed_when: false
+  ignore_errors: true
+  register: motd__register_shell_shellcheck
+
+- name: Print warning message if shellcheck of '{{ looped_script_template }}' error'd.
+  ansible.builtin.fail:
+    msg: "Warning: '{{ looped_script_template }}' contains shellcheck errors - not adding to dynamic motd scripts directory!"
+  ignore_errors: true
+  when: motd__register_shell_shellcheck.rc != 0
+
+# shellcheck ok:
+- name: Copy generated dynamic MOTD script  '{{ looped_script_template }}' to actual directory and ensure correct owner/group/mode.
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ motd__register_tempfile_dynamic_motds.path }}/{{ looped_script_template }}"
+    dest: "{{ motd_dynamic_scripts_directory }}/{{ looped_script_template }}"
+    owner: root
+    group: root
+    mode: u=rwx,g=rx,o=rx
+  when: motd__register_shell_shellcheck.rc == 0

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -1,10 +1,2 @@
 ---
 # tasks file for testing that variables of ansible-role jonaspammer.motd are set correctly
-
-- name: test if variable_name is set correctly
-  ansible.builtin.assert:
-    that:
-      - variable_name is defined
-      - variable_name is number
-      - variable_name >= 0
-    quiet: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,3 +5,11 @@
   ansible.builtin.import_tasks: assert.yml
   run_once: true
   delegate_to: localhost
+
+- name: stat static MOTD file
+  ansible.builtin.stat:
+    path: "/etc/motd"
+  register: motd__register_stat_static_motd_file
+
+- name: Include appropriate Tasks depending on motd_type.
+  ansible.builtin.include_tasks: setup-{{ motd_type }}.yml

--- a/tasks/setup-static.yml
+++ b/tasks/setup-static.yml
@@ -1,0 +1,26 @@
+---
+# tasks file of ansible-role jonaspammer.motd
+
+- name: Generate static MOTD file and ensure correct owner/group/mode.
+  ansible.builtin.template:
+    src: "{{ motd_static_motd_template }}.jinja2"
+    dest: "/etc/motd"
+    owner: root
+    group: root
+    mode: u=rwx,g=rx,o=rx
+
+- name: stat dynamic motd directory
+  ansible.builtin.stat:
+    path: "{{ motd_dynamic_scripts_directory }}"
+  register: motd__register_stat_dynamic_motd_directory
+- block:
+    - name: Copy dynamic MOTD files into preservation directory (when exists and preservation configured).
+      ansible.builtin.copy:
+        remote_src: true
+        src: "{{ motd_dynamic_scripts_directory }}"
+        dest: "{{ motd_dynamic_scripts_backup_path }}"
+    - name: Delete dynamic MOTD script directory.
+      ansible.builtin.file:
+        path: "{{ motd_dynamic_scripts_directory }}"
+        state: absent
+  when: motd__register_stat_dynamic_motd_directory.stat.exists

--- a/tasks/setup-update-motd.yml
+++ b/tasks/setup-update-motd.yml
@@ -1,0 +1,82 @@
+---
+# tasks file of ansible-role jonaspammer.motd
+
+# TODO add tasks to install a mimic of update-motd's functionality
+#      on systems that don't have Ubuntu's pam_motd patch.
+#      See https://ownyourbits.com/2017/04/05/customize-your-motd-login-message-in-debian-and-ubuntu/
+#      for guidance on how to accomplish / update-motd's parts.
+- name: fail if not ubuntu until update-motd mimic implementation is implemented
+  ansible.builtin.fail:
+  when: ansible_distribution != 'Ubuntu'
+
+- block:
+    - name: Preserve static MOTD file (when exists and preservation configured).
+      ansible.builtin.copy:
+        remote_src: true
+        src: "/etc/motd"
+        dest: "{{ motd_static_motd_backup_path }}"
+      when: motd_static_motd_backup
+    - name: Delete static MOTD file (when distribution is Ubuntu).
+      ansible.builtin.file:
+        path: "/etc/motd"
+        state: absent
+      # TODO uncomment the "when" when the mimicked update-motd (which will symlink /etc/motd
+      #      to mentioned dynamically generated motd.dynamic file) has been implemented
+      # Symlink from `/etc/motd` to `/var/run/motd.dynamic` does not even need to exist anymore
+      # since Ubuntu 16.04 LTS's `pam_motd` implementation of the update-motd functionality
+      # no longer depends on that.
+      # when: ansible_distribution == 'Ubuntu'
+  when: motd__register_stat_static_motd_file.stat.exists
+
+- name: Install tools used in dynamic MOTDs from the system's package manager.
+  ansible.builtin.package:
+    name: "{{ motd_dynamic_scripts_system_packages }}"
+    state: present
+
+- name: find files in dynamic MOTD script directory that should not exist
+  ansible.builtin.find:
+    paths: "{{ motd_dynamic_scripts_directory }}"
+    file_type: file
+    excludes: "{{ motd_dynamic_scripts_templates }}"
+  register: motd__register_find_undefined_dynamic_motd_files
+- block:
+    - name: create preservation directory for dynamic MOTD scripts that should not exist (when exists and preservation configured).
+      ansible.builtin.file:
+        state: directory
+        path: "{{ motd_dynamic_scripts_backup_path }}"
+      register: motd__register_file_dynamic_motd_backup_dir
+    - name: Copy dynamic MOTD files that should not exist into preservation directory (when exists and preservation configured).
+      ansible.builtin.copy:
+        remote_src: true
+        src: "{{ item.path }}"
+        dest: "{{ motd__register_file_dynamic_motd_backup_dir.path }}/{{ item.path | basename }}"
+      loop: "{{ motd__register_find_undefined_dynamic_motd_files.files }}"
+      loop_control:
+        label: "{{ item.path }}"
+  when: motd_dynamic_scripts_backup and motd__register_find_undefined_dynamic_motd_files.matched != 0
+- name: Delete dynamic MOTD scripts that should not exist.
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ motd__register_find_undefined_dynamic_motd_files.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+
+- name: Create dynamic MOTD scripts directory and ensure correct owner/group.
+  ansible.builtin.file:
+    state: directory
+    path: "{{ motd_dynamic_scripts_directory }}"
+    owner: root
+    group: root
+    mode: u=rwx,g=rx,o=rx
+- name: create temporary directory to generate MOTD script templates into
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: "-dynamic-motd-scripts"
+  register: motd__register_tempfile_dynamic_motds
+  changed_when: false
+- name: Include Tasks to generate and copy every dynamic MOTD script template that shellcheck's correctly.
+  ansible.builtin.include_tasks: add-dynamic-script.yml
+  loop: "{{ motd_dynamic_scripts_templates }}"
+  loop_control:
+    loop_var: looped_script_template

--- a/templates/00-legal.jinja2
+++ b/templates/00-legal.jinja2
@@ -3,8 +3,13 @@
 # ---
 {# /etc/update-motd.d/00-legal #}
 
+temp_file=$(mktemp)
+cat << EOFHEREDOC > "$temp_file"
+{% include 'templates/issue.net.jinja2' | replace('HEREDOC', 'EOF HEREDOC') %}
+EOFHEREDOC
+
 if ! command -v boxes &> /dev/null; then
-  cat /etc/issue.net
+  cat "${temp_file}"
 else
-  boxes -d parchment < /etc/issue.net
+  boxes -d parchment < "${temp_file}"
 fi

--- a/templates/00-legal.jinja2
+++ b/templates/00-legal.jinja2
@@ -1,0 +1,10 @@
+#!/bin/bash
+# {{ ansible_managed }}
+# ---
+{# /etc/update-motd.d/00-legal #}
+
+if ! command -v boxes &> /dev/null; then
+  cat /etc/issue.net
+else
+  boxes -d parchment < /etc/issue.net
+fi

--- a/templates/10-sysinfo.jinja2
+++ b/templates/10-sysinfo.jinja2
@@ -1,0 +1,6 @@
+#!/bin/bash
+# {{ ansible_managed }}
+# ---
+{# /etc/update-motd.d/20-sysinfo #}
+
+neofetch || screenfetch || uname -a

--- a/templates/issue.net.jinja2
+++ b/templates/issue.net.jinja2
@@ -1,0 +1,16 @@
+{# /etc/issue.net   - Used as BANNER in /etc/ssh/sshd_config and by dynamic MOTD script 00-legal.jinja2.bash #}
+You are connecting to the computer system '{{ ansible_hostname }}'{% if motd_legal_location_name is defined %} at {{ motd_legal_location_name }}{% endif %}.
+
+Any or all uses of this system and all files on this system may be
+intercepted, monitored, recorded, copied, audited, inspected,
+and disclosed to authorized corporation and law enforcement personnel,
+as well as authorized individuals of other organizations.
+By using this system, the user consents to such interception,
+monitoring, recording, copying, auditing, inspection,
+and disclosure at the discretion of authorized personnel.
+
+Unauthorized or improper use of this system may result in
+administrative disciplinary action, civil charges/criminal penalties,
+and/or other sanctions as according to the european codes and/or countries codes.
+
+LOG OFF IMMEDIATELY if you do not agree to the conditions stated in this warning.

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,7 @@
 ---
 # vars file of ansible-role jonaspammer.motd
 # (tl;dr: almost not overwrite-able variables)
+
+
+_motd_dynamic_scripts_directory:
+  default: "/etc/update-motd.d"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,15 +1,3 @@
 ---
 # vars file of ansible-role jonaspammer.motd
 # (tl;dr: almost not overwrite-able variables)
-
-_motd_somevar:
-  Debian: ""
-  Debian_10: ""
-  RedHat: ""
-
-motd_somevar: "{{
-  _motd_somevar[ansible_distribution ~ '_' ~ ansible_distribution_major_version]|default(
-  _motd_somevar[ansible_os_family ~ '_' ~ ansible_distribution_major_version])|default(
-  _motd_somevar[ansible_distribution])|default(
-  _motd_somevar[ansible_os_family])|default(
-  _motd_somevar['default']) }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,6 +2,5 @@
 # vars file of ansible-role jonaspammer.motd
 # (tl;dr: almost not overwrite-able variables)
 
-
 _motd_dynamic_scripts_directory:
   default: "/etc/update-motd.d"


### PR DESCRIPTION
v1 does not contain the functionality to mimic update-motd on systems that weren't patched with Ubuntu's update-motd functionality. motd_type is set to static for non-Ubuntu systems for now. 

Documentation should be looked over as I've live-changed many things in the last hours.

Tests are still to be made before releasing v1 (find out how).

## **Required Checklist**

- [x] Documentation has been altered or extended appropriately
- [ ] This pull request and its commits address only a single concern
- [x] I have followed [JonasPammer's Ansible Role Development Guidelines](https://github.com/JonasPammer/cookiecutter-ansible-role/blob/master/ROLE_DEVELOPMENT_GUIDELINES.adoc)
- [x] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

## _Optional_ Checklist

- [x] pre-commit was installed in local development environment (if not, a GitHub workflow will run pre-commit once you create the request)

- [ ] my commits are small, single-purpose, detailed and maybe even follow the [conventional commit specification](https://gist.github.com/JonasPammer/4ea577854ae10afe644bff366d7b2a8a) for extra convenience of the reviewer
